### PR TITLE
Add boss enemy spawn every 5 waves

### DIFF
--- a/Assets/Scripts/BossEnemyController.cs
+++ b/Assets/Scripts/BossEnemyController.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class BossEnemyController : MonoBehaviour {
+    GameObject player;
+    GameObject gameManager;
+    public int maxHealth = 50;
+    private int currentHealth;
+    public int damage = 20;
+
+    void Start() {
+        player = GameObject.FindGameObjectWithTag("Player");
+        gameManager = GameObject.Find("GameManager");
+        currentHealth = maxHealth;
+    }
+
+    void Update() {
+        MoveToPlayer();
+    }
+
+    private void MoveToPlayer() {
+        if (player == null)
+            return;
+        // Boss moves slightly faster towards the player
+        transform.position = Vector3.Lerp(transform.position, player.transform.position, Random.Range(0.5f, 1.2f) * Time.deltaTime);
+    }
+
+    public void TakeDamage(int amount) {
+        currentHealth -= amount;
+        if (currentHealth <= 0) {
+            if (gameManager != null) {
+                GameManager gm = gameManager.GetComponent<GameManager>();
+                gm.Score += 100;
+                gm.scoreText.text = "Point : " + gm.Score;
+            }
+            Destroy(gameObject);
+        }
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision) {
+        if (collision.name.Equals("Player")) {
+            collision.GetComponent<PlayerHealth>().TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/Scripts/BossEnemyController.cs.meta
+++ b/Assets/Scripts/BossEnemyController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd8d5968bf4b4285876805139569db2c

--- a/Assets/Scripts/BulletController.cs
+++ b/Assets/Scripts/BulletController.cs
@@ -11,6 +11,13 @@ public class BulletController : MonoBehaviour {
 
     private void OnTriggerEnter2D(Collider2D collision) {
         if (!collision.name.Equals("Player") && !collision.name.Equals("Walls")) {
+            BossEnemyController boss = collision.GetComponent<BossEnemyController>();
+            if (boss != null) {
+                boss.TakeDamage(5);
+                Destroy(gameObject);
+                return;
+            }
+
             if (collision.name.Contains("Enemy")) {
                 gameManager.GetComponent<GameManager>().Score += 10;
                 gameManager.GetComponent<GameManager>().scoreText.text = "Point : " + gameManager.GetComponent<GameManager>().Score;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,6 +7,7 @@ public class GameManager : MonoBehaviour {
     public GameObject Player;
     public GameObject Enemy;
     public GameObject BonusHP;
+    public GameObject BossEnemy;
 
     // Enemy Spawn Variables
     public int enemiesPerWave = 10;
@@ -53,10 +54,10 @@ public class GameManager : MonoBehaviour {
         float spawnBuffer = Random.Range(0.5f, 3f);
 
         Vector3 spawnPos = Vector3.zero;
-        int side = Random.Range(0, 4); // 0=üst, 1=alt, 2=sað, 3=sol
+        int side = Random.Range(0, 4); // 0=Ã¼st, 1=alt, 2=saÄŸ, 3=sol
 
         switch (side) {
-            case 0: // ÜST
+            case 0: // ÃœST
                 spawnPos = new Vector3(
                     Random.Range(camMin.x, camMax.x),
                     camMax.y + spawnBuffer,
@@ -68,7 +69,7 @@ public class GameManager : MonoBehaviour {
                     camMin.y - spawnBuffer,
                     0);
                 break;
-            case 2: // SAÐ
+            case 2: // SAÄž
                 spawnPos = new Vector3(
                     camMax.x + spawnBuffer,
                     Random.Range(camMin.y, camMax.y),
@@ -85,13 +86,24 @@ public class GameManager : MonoBehaviour {
         Instantiate(Enemy, spawnPos, Quaternion.identity);
     }
 
+    void SpawnBossEnemy() {
+        if (Player == null) return;
+        Vector3 camMin = Camera.main.ViewportToWorldPoint(new Vector3(0, 0, 0));
+        Vector3 camMax = Camera.main.ViewportToWorldPoint(new Vector3(1, 1, 0));
+        Vector3 spawnPos = new Vector3(Random.Range(camMin.x, camMax.x), camMax.y + 2f, 0);
+        Instantiate(BossEnemy, spawnPos, Quaternion.identity);
+    }
+
     void StartNewWave() {
         currentWave++;
         int totalEnemies = enemiesPerWave + currentWave * 2;
 
-        Debug.Log($"* Dalga {currentWave} baþlýyor! ({totalEnemies} düþman)");
+        Debug.Log($"* Dalga {currentWave} baÅŸlÄ±yor! ({totalEnemies} dÃ¼ÅŸman)");
         waveText.text = "Wave " + currentWave;
         StartCoroutine(SpawnEnemiesWithDelay(totalEnemies));
+        if (currentWave % 5 == 0) {
+            SpawnBossEnemy();
+        }
     }
 
     IEnumerator SpawnEnemiesWithDelay(int count) {


### PR DESCRIPTION
## Summary
- add `BossEnemyController` to manage boss HP and damage
- modify `BulletController` to damage boss instead of destroying instantly
- convert `GameManager.cs` to UTF-8 and add boss spawn logic
- spawn a boss enemy every 5 waves

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856f45ebfa88333aeacc6ab8c6d2007